### PR TITLE
Add agenttrace to terminal tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ AI enhancements for command-line interfaces:
 - **[Warp](https://www.warp.dev/)** - AI Terminal
 - **[Wave](https://www.waveterm.dev/)** - Stop context switching by bringing context into your terminal
 - **[Tabby](https://tabby.sh/)** - A terminal for the modern age
+- **[agenttrace](https://github.com/luoyuctl/agenttrace)** - Local TUI for reviewing AI coding agent session cost, tokens, latency, failures, and health
 
 ### AI Software Engineers
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -81,6 +81,7 @@
 - **[Warp](https://www.warp.dev/)** - AI终端
 - **[Wave](https://www.waveterm.dev/)** - 将上下文引入终端，停止上下文切换
 - **[Tabby](https://tabby.sh/)** - 现代化的终端
+- **[agenttrace](https://github.com/luoyuctl/agenttrace)** - 本地 TUI，用于查看 AI 编码智能体会话的成本、token、延迟、失败和健康度
 
 ### AI软件工程师
 

--- a/coding.mdx
+++ b/coding.mdx
@@ -171,6 +171,7 @@ Warp is an AI-enhanced terminal.
 
 - **Wave**: Stop context switching by bringing context into your terminal [https://www.waveterm.dev/](https://www.waveterm.dev/)
 - **Tabby**: A terminal for the modern age [https://tabby.sh/](https://tabby.sh/)
+- **agenttrace**: Local TUI for reviewing AI coding agent session cost, tokens, latency, failures, and health [https://github.com/luoyuctl/agenttrace](https://github.com/luoyuctl/agenttrace)
 
 ## AI Software Engineers
 

--- a/coding.zh-CN.mdx
+++ b/coding.zh-CN.mdx
@@ -174,6 +174,7 @@ Warp 是一款 AI 增强型终端。
 
 - **Wave**：通过将上下文引入终端来停止上下文切换 [https://www.waveterm.dev/](https://www.waveterm.dev/)
 - **Tabby**：现代终端 [https://tabby.sh/](https://tabby.sh/)
+- **agenttrace**：本地 TUI，用于查看 AI 编码智能体会话的成本、token、延迟、失败和健康度 [https://github.com/luoyuctl/agenttrace](https://github.com/luoyuctl/agenttrace)
 
 ## AI 软件工程师
 

--- a/data/aiTools.ts
+++ b/data/aiTools.ts
@@ -277,7 +277,7 @@ export interface AiTool {
       outputType: 'Terminal',
     },
     {
-      whatsTheName: 'agenttrace',
+      whatsTheName: 'Agenttrace',
       urlLink: 'https://github.com/luoyuctl/agenttrace',
       description: 'Local TUI for reviewing AI coding agent session cost, tokens, latency, failures, and health',
       company: '',

--- a/data/aiTools.ts
+++ b/data/aiTools.ts
@@ -276,6 +276,14 @@ export interface AiTool {
       howToUseType: 'Terminal',
       outputType: 'Terminal',
     },
+    {
+      whatsTheName: 'agenttrace',
+      urlLink: 'https://github.com/luoyuctl/agenttrace',
+      description: 'Local TUI for reviewing AI coding agent session cost, tokens, latency, failures, and health',
+      company: '',
+      howToUseType: 'Terminal',
+      outputType: 'Terminal',
+    },
     // AI 软件工程师 (AI software engineer)
     {
       whatsTheName: 'MetaGPT',


### PR DESCRIPTION
Adds agenttrace as a terminal AI coding tool in the English/Chinese README, MDX content, and the data source used by the site.

agenttrace is a local TUI for reviewing AI coding agent session history across cost, tokens, latency, tool failures, anomalies, health, and reports.

Checks:
- pnpm install --frozen-lockfile
- pnpm build
- git diff --check

Note: `pnpm build` completed successfully. It emitted existing project warnings about ESLint option compatibility and package module type, but the Next.js production build and static generation succeeded.